### PR TITLE
Change to difficulty-specific link for osu!direct.

### DIFF
--- a/front-end/src/app/components/game-lobby/beatmap-info/beatmap-info.component.ts
+++ b/front-end/src/app/components/game-lobby/beatmap-info/beatmap-info.component.ts
@@ -51,7 +51,7 @@ export class BeatmapInfoComponent implements OnInit {
   get osuDirectLink() {
     return (
       this.beatmap &&
-      this.sanitizer.bypassSecurityTrustUrl(`osu://dl/${this.beatmap.beatmapset_id}`)
+      this.sanitizer.bypassSecurityTrustUrl(`osu://b/${this.beatmap.beatmap_id}`)
     );
   }
 


### PR DESCRIPTION
With a whopping five characters changed, this fixes #22.

Thanks to @Zyfarok for reporting this.